### PR TITLE
raise RuntimeError on python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
-from setuptools import setup, find_packages
+import sys
 from codecs import open
 from os import path
+
+from setuptools import find_packages, setup
+
+if sys.version_info.major < 3:
+    raise RuntimeError('Please use python3 to install this package')
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
`python_requires` argument for `setuptools.setup` didn't work for my python2, so I just added a simple condition to check python version