### PR TITLE
Reorder some rules

### DIFF
--- a/kin/grammar/PBXProj.g4
+++ b/kin/grammar/PBXProj.g4
@@ -937,15 +937,12 @@ any_string
 // LEXER
 
 // Keywords
-
 CLASSES: 'classes';
 ISA: 'isa';
 OBJECTS: 'objects';
 ROOT_OBJECT: 'rootObject';
-NUMBER: ('0'..'9')+;
+NUMBER: [0-9]+;
 DOT: '.';
-ALPHA_NUMERIC: [0-9a-zA-Z];
-ALPHA_NUMERIC_CAP: [0-9A-Z];
 DASH: '-';
 UNDERSCORE: '_';
 SLASH: '/';
@@ -979,6 +976,9 @@ QUOTED_STRING
 NON_QUOTED_STRING: (ALPHA_NUMERIC|UNDERSCORE|DASH|SLASH|DOT)+;
 
 VARIABLE: ('$' NON_QUOTED_STRING) + SLASH?;
+
+ALPHA_NUMERIC: [0-9a-zA-Z];
+ALPHA_NUMERIC_CAP: [0-9A-Z];
 
 fragment HEX
     : [0-9a-fA-F]

--- a/tests/ok/011.pbxproj
+++ b/tests/ok/011.pbxproj
@@ -1,0 +1,718 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4073733CAB3A0DFF92509CB4 /* Pods_MitsumoriUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50207757D99BA58B73384B1C /* Pods_MitsumoriUITests.framework */; };
+		40B8192350A5E6A7FD028AF1 /* Pods_Mitsumori.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9C8B51DFD24BD194B40CE8 /* Pods_Mitsumori.framework */; };
+		490970611C16D9A900200801 /* UIViewTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490970601C16D9A900200801 /* UIViewTransform.swift */; };
+		495413B61C1424A20071F4A0 /* CardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495413B51C1424A20071F4A0 /* CardViewModel.swift */; };
+		4959011B1C58F8AB000EE944 /* CustomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4959011A1C58F8AB000EE944 /* CustomView.swift */; };
+		4973659F1C19BC6E00837617 /* MitsumoriUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4973659E1C19BC6E00837617 /* MitsumoriUITests.swift */; };
+		497365A91C19BD5A00837617 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 497365A81C19BD5A00837617 /* Nimble.framework */; };
+		49C4EEDE1C5E152800B38CD9 /* SelectedCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C4EEDD1C5E152800B38CD9 /* SelectedCardViewModel.swift */; };
+		49F0E1DF1C1B28FF0074B5B7 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0E1DE1C1B28FF0074B5B7 /* SnapshotHelper.swift */; };
+		49F0E1E11C1B300E0074B5B7 /* SnapshotCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0E1E01C1B300E0074B5B7 /* SnapshotCapturer.swift */; };
+		49F4A5891C583A95007C84A1 /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5881C583A95007C84A1 /* Animation.swift */; };
+		49F4A58B1C583AB3007C84A1 /* Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A58A1C583AB3007C84A1 /* Transform.swift */; };
+		49F4A58D1C583AE3007C84A1 /* CGPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A58C1C583AE3007C84A1 /* CGPoint.swift */; };
+		49F4A58F1C583AF3007C84A1 /* CGSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A58E1C583AF3007C84A1 /* CGSize.swift */; };
+		49F4A5911C583B0C007C84A1 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5901C583B0C007C84A1 /* Card.swift */; };
+		49F4A5931C583B4C007C84A1 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5921C583B4C007C84A1 /* Double.swift */; };
+		49F4A5951C583B61007C84A1 /* FrontCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5941C583B61007C84A1 /* FrontCardView.swift */; };
+		49F4A5971C583B94007C84A1 /* FrontCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49F4A5961C583B94007C84A1 /* FrontCardView.xib */; };
+		49F4A5991C583BAF007C84A1 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5981C583BAF007C84A1 /* Math.swift */; };
+		49F4A59F1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A59E1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift */; };
+		49F4A5A11C583DAE007C84A1 /* RotateSelectCardAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5A01C583DAE007C84A1 /* RotateSelectCardAnimation.swift */; };
+		49F4A5A31C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F4A5A21C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift */; };
+		49FBBF921C10C2A200A1A4BB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBF911C10C2A200A1A4BB /* AppDelegate.swift */; };
+		49FBBF971C10C2A200A1A4BB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49FBBF951C10C2A200A1A4BB /* Main.storyboard */; };
+		49FBBF991C10C2A200A1A4BB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 49FBBF981C10C2A200A1A4BB /* Assets.xcassets */; };
+		49FBBF9C1C10C2A200A1A4BB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49FBBF9A1C10C2A200A1A4BB /* LaunchScreen.storyboard */; };
+		49FBBFC01C10D05800A1A4BB /* CardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBFBF1C10D05800A1A4BB /* CardCollectionViewCell.swift */; };
+		49FBBFC41C10EBE600A1A4BB /* CardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBFC31C10EBE600A1A4BB /* CardsViewController.swift */; };
+		49FBBFC81C10FB9C00A1A4BB /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FBBFC71C10FB9C00A1A4BB /* UIView.swift */; };
+		EBFE74EE1C4900D000B7B646 /* BackCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFE74ED1C4900D000B7B646 /* BackCardView.swift */; };
+		EBFE74F01C4900EB00B7B646 /* BackCardView.xib in Resources */ = {isa = PBXBuildFile; fileRef = EBFE74EF1C4900EB00B7B646 /* BackCardView.xib */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		497365A11C19BC6E00837617 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 49FBBF861C10C2A200A1A4BB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 49FBBF8D1C10C2A200A1A4BB;
+			remoteInfo = Mitsumori;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0D90B4EBF4714D2C4F8805EE /* Pods_MitsumoriTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MitsumoriTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		274E42B0193BA6FEFA8FD71C /* Pods-MitsumoriUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MitsumoriUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MitsumoriUITests/Pods-MitsumoriUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		2757E033CFB59572DA4E60B3 /* Pods-MitsumoriUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MitsumoriUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MitsumoriUITests/Pods-MitsumoriUITests.release.xcconfig"; sourceTree = "<group>"; };
+		490970601C16D9A900200801 /* UIViewTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewTransform.swift; sourceTree = "<group>"; };
+		495413B51C1424A20071F4A0 /* CardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardViewModel.swift; sourceTree = "<group>"; };
+		4959011A1C58F8AB000EE944 /* CustomView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomView.swift; sourceTree = "<group>"; };
+		4973659C1C19BC6E00837617 /* MitsumoriUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MitsumoriUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4973659E1C19BC6E00837617 /* MitsumoriUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MitsumoriUITests.swift; sourceTree = "<group>"; };
+		497365A01C19BC6E00837617 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		497365A61C19BC9500837617 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Pods/../build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		497365A81C19BD5A00837617 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Pods/../build/Debug-iphoneos/Nimble.framework"; sourceTree = "<group>"; };
+		49C4EEDD1C5E152800B38CD9 /* SelectedCardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectedCardViewModel.swift; sourceTree = "<group>"; };
+		49F0E1DE1C1B28FF0074B5B7 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		49F0E1E01C1B300E0074B5B7 /* SnapshotCapturer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotCapturer.swift; sourceTree = "<group>"; };
+		49F4A5881C583A95007C84A1 /* Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
+		49F4A58A1C583AB3007C84A1 /* Transform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transform.swift; sourceTree = "<group>"; };
+		49F4A58C1C583AE3007C84A1 /* CGPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGPoint.swift; sourceTree = "<group>"; };
+		49F4A58E1C583AF3007C84A1 /* CGSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGSize.swift; sourceTree = "<group>"; };
+		49F4A5901C583B0C007C84A1 /* Card.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		49F4A5921C583B4C007C84A1 /* Double.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
+		49F4A5941C583B61007C84A1 /* FrontCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrontCardView.swift; sourceTree = "<group>"; };
+		49F4A5961C583B94007C84A1 /* FrontCardView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FrontCardView.xib; sourceTree = "<group>"; };
+		49F4A5981C583BAF007C84A1 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
+		49F4A59E1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RotateRevealSelectedCardAnimation.swift; sourceTree = "<group>"; };
+		49F4A5A01C583DAE007C84A1 /* RotateSelectCardAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RotateSelectCardAnimation.swift; sourceTree = "<group>"; };
+		49F4A5A21C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlideToSideRestoreAnimation.swift; sourceTree = "<group>"; };
+		49FBBF8E1C10C2A200A1A4BB /* Mitsumori.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mitsumori.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		49FBBF911C10C2A200A1A4BB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		49FBBF961C10C2A200A1A4BB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		49FBBF981C10C2A200A1A4BB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		49FBBF9B1C10C2A200A1A4BB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		49FBBF9D1C10C2A200A1A4BB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		49FBBFBF1C10D05800A1A4BB /* CardCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardCollectionViewCell.swift; sourceTree = "<group>"; };
+		49FBBFC31C10EBE600A1A4BB /* CardsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardsViewController.swift; sourceTree = "<group>"; };
+		49FBBFC71C10FB9C00A1A4BB /* UIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIView.swift; sourceTree = "<group>"; };
+		50207757D99BA58B73384B1C /* Pods_MitsumoriUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MitsumoriUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E9C8B51DFD24BD194B40CE8 /* Pods_Mitsumori.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Mitsumori.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		83CD4CEBE1B7A02772169FE5 /* Pods-Mitsumori.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mitsumori.release.xcconfig"; path = "Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori.release.xcconfig"; sourceTree = "<group>"; };
+		EBFE74ED1C4900D000B7B646 /* BackCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackCardView.swift; sourceTree = "<group>"; };
+		EBFE74EF1C4900EB00B7B646 /* BackCardView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BackCardView.xib; sourceTree = "<group>"; };
+		F128C4D0067FEE87B2756BC4 /* Pods-Mitsumori.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mitsumori.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori.debug.xcconfig"; sourceTree = "<group>"; };
+		FR_FE870E28DC2371E7ACA886F03F460581 /* Something.xcconfig */ = {isa = PBXFileReference; explicitFileType = text.xcconfig; name = "Something.xcconfig"; path = "Configurations/Something.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		497365991C19BC6E00837617 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				497365A91C19BD5A00837617 /* Nimble.framework in Frameworks */,
+				4073733CAB3A0DFF92509CB4 /* Pods_MitsumoriUITests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49FBBF8B1C10C2A200A1A4BB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40B8192350A5E6A7FD028AF1 /* Pods_Mitsumori.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B3AF46E021071CA6002211EE /* C */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = C;
+			sourceTree = "<group>";
+		};
+		3F7D3EDF02E1003A4134947D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				274E42B0193BA6FEFA8FD71C /* Pods-MitsumoriUITests.debug.xcconfig */,
+				2757E033CFB59572DA4E60B3 /* Pods-MitsumoriUITests.release.xcconfig */,
+				F128C4D0067FEE87B2756BC4 /* Pods-Mitsumori.debug.xcconfig */,
+				83CD4CEBE1B7A02772169FE5 /* Pods-Mitsumori.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		4973659D1C19BC6E00837617 /* MitsumoriUITests */ = {
+			isa = PBXGroup;
+			children = (
+				49F0E1DE1C1B28FF0074B5B7 /* SnapshotHelper.swift */,
+				4973659E1C19BC6E00837617 /* MitsumoriUITests.swift */,
+				497365A01C19BC6E00837617 /* Info.plist */,
+				49F0E1E01C1B300E0074B5B7 /* SnapshotCapturer.swift */,
+			);
+			path = MitsumoriUITests;
+			sourceTree = "<group>";
+		};
+		49F4A5811C583958007C84A1 /* Animation */ = {
+			isa = PBXGroup;
+			children = (
+				49F4A5881C583A95007C84A1 /* Animation.swift */,
+				49F4A59E1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift */,
+				49F4A5A01C583DAE007C84A1 /* RotateSelectCardAnimation.swift */,
+				49F4A5A21C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift */,
+			);
+			name = Animation;
+			sourceTree = "<group>";
+		};
+		49F4A5821C583998007C84A1 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				49F4A58C1C583AE3007C84A1 /* CGPoint.swift */,
+				49F4A58E1C583AF3007C84A1 /* CGSize.swift */,
+				49F4A5921C583B4C007C84A1 /* Double.swift */,
+				49FBBFC71C10FB9C00A1A4BB /* UIView.swift */,
+				490970601C16D9A900200801 /* UIViewTransform.swift */,
+				49F4A5981C583BAF007C84A1 /* Math.swift */,
+			);
+			name = Extension;
+			sourceTree = "<group>";
+		};
+		49F4A5831C5839A1007C84A1 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				49F4A5901C583B0C007C84A1 /* Card.swift */,
+			);
+			name = Model;
+			sourceTree = "<group>";
+		};
+		49F4A5841C5839B0007C84A1 /* Storyboard */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBF9A1C10C2A200A1A4BB /* LaunchScreen.storyboard */,
+				49FBBF951C10C2A200A1A4BB /* Main.storyboard */,
+			);
+			name = Storyboard;
+			sourceTree = "<group>";
+		};
+		49F4A5851C5839B7007C84A1 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				EBFE74ED1C4900D000B7B646 /* BackCardView.swift */,
+				EBFE74EF1C4900EB00B7B646 /* BackCardView.xib */,
+				49FBBFBF1C10D05800A1A4BB /* CardCollectionViewCell.swift */,
+				4959011A1C58F8AB000EE944 /* CustomView.swift */,
+				49F4A5941C583B61007C84A1 /* FrontCardView.swift */,
+				49F4A5961C583B94007C84A1 /* FrontCardView.xib */,
+				49F4A58A1C583AB3007C84A1 /* Transform.swift */,
+			);
+			name = View;
+			sourceTree = "<group>";
+		};
+		49F4A5861C583A12007C84A1 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBFC31C10EBE600A1A4BB /* CardsViewController.swift */,
+			);
+			name = ViewController;
+			sourceTree = "<group>";
+		};
+		49F4A5871C583A25007C84A1 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				495413B51C1424A20071F4A0 /* CardViewModel.swift */,
+				49C4EEDD1C5E152800B38CD9 /* SelectedCardViewModel.swift */,
+			);
+			name = ViewModel;
+			sourceTree = "<group>";
+		};
+		49FBBF851C10C2A200A1A4BB = {
+			isa = PBXGroup;
+			children = (
+				49FBBF901C10C2A200A1A4BB /* Mitsumori */,
+				4973659D1C19BC6E00837617 /* MitsumoriUITests */,
+				49FBBF8F1C10C2A200A1A4BB /* Products */,
+				3F7D3EDF02E1003A4134947D /* Pods */,
+				843513CC76A2B252F7CE6020 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		49FBBF8F1C10C2A200A1A4BB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBF8E1C10C2A200A1A4BB /* Mitsumori.app */,
+				4973659C1C19BC6E00837617 /* MitsumoriUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		49FBBF901C10C2A200A1A4BB /* Mitsumori */ = {
+			isa = PBXGroup;
+			children = (
+				49FBBF981C10C2A200A1A4BB /* Assets.xcassets */,
+				49FBBF9D1C10C2A200A1A4BB /* Info.plist */,
+				49F4A5811C583958007C84A1 /* Animation */,
+				49F4A5821C583998007C84A1 /* Extension */,
+				49F4A5831C5839A1007C84A1 /* Model */,
+				49F4A5841C5839B0007C84A1 /* Storyboard */,
+				49F4A5851C5839B7007C84A1 /* View */,
+				49F4A5861C583A12007C84A1 /* ViewController */,
+				49F4A5871C583A25007C84A1 /* ViewModel */,
+				49FBBF911C10C2A200A1A4BB /* AppDelegate.swift */,
+			);
+			path = Mitsumori;
+			sourceTree = "<group>";
+		};
+		843513CC76A2B252F7CE6020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				497365A81C19BD5A00837617 /* Nimble.framework */,
+				497365A61C19BC9500837617 /* Nimble.framework */,
+				0D90B4EBF4714D2C4F8805EE /* Pods_MitsumoriTests.framework */,
+				50207757D99BA58B73384B1C /* Pods_MitsumoriUITests.framework */,
+				5E9C8B51DFD24BD194B40CE8 /* Pods_Mitsumori.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		G_78452DDA02BFEF5D6BA29AEFB4B1266A /* Configurations */ = {
+			isa = PBXGroup;
+			children = (
+				FR_FE870E28DC2371E7ACA886F03F460581 /* Something.xcconfig */,
+			);
+			name = Configurations;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4973659B1C19BC6E00837617 /* MitsumoriUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 497365A31C19BC6E00837617 /* Build configuration list for PBXNativeTarget "MitsumoriUITests" */;
+			buildPhases = (
+				0D338338AD469905FE45C5D7 /* Check Pods Manifest.lock */,
+				497365981C19BC6E00837617 /* Sources */,
+				497365991C19BC6E00837617 /* Frameworks */,
+				4973659A1C19BC6E00837617 /* Resources */,
+				77A1B287EDAA82F36793B49B /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				497365A21C19BC6E00837617 /* PBXTargetDependency */,
+			);
+			name = MitsumoriUITests;
+			productName = MitsumoriUITests;
+			productReference = 4973659C1C19BC6E00837617 /* MitsumoriUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		49FBBF8D1C10C2A200A1A4BB /* Mitsumori */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 49FBBFB61C10C2A200A1A4BB /* Build configuration list for PBXNativeTarget "Mitsumori" */;
+			buildPhases = (
+				B413487ECFAF19CC720F6703 /* Check Pods Manifest.lock */,
+				49FBBF8A1C10C2A200A1A4BB /* Sources */,
+				49FBBF8B1C10C2A200A1A4BB /* Frameworks */,
+				49FBBF8C1C10C2A200A1A4BB /* Resources */,
+				E09A62F1C2781CCB49DC3900 /* Embed Pods Frameworks */,
+				19FA3CFC97A494716FCCD298 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Mitsumori;
+			productName = Mitsumori;
+			productReference = 49FBBF8E1C10C2A200A1A4BB /* Mitsumori.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		49FBBF861C10C2A200A1A4BB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				DefaultBuildSystemTypeForWorkspace = Original;
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0710;
+				ORGANIZATIONNAME = Karumi;
+				TargetAttributes = {
+					4973659B1C19BC6E00837617 = {
+						CreatedOnToolsVersion = 7.2;
+						TestTargetID = 49FBBF8D1C10C2A200A1A4BB;
+					};
+					49FBBF8D1C10C2A200A1A4BB = {
+						CreatedOnToolsVersion = 7.1.1;
+						DevelopmentTeam = BD48FG9BMV;
+					};
+				};
+			};
+			buildConfigurationList = 49FBBF891C10C2A200A1A4BB /* Build configuration list for PBXProject "Mitsumori" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 49FBBF851C10C2A200A1A4BB;
+			productRefGroup = 49FBBF8F1C10C2A200A1A4BB /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				49FBBF8D1C10C2A200A1A4BB /* Mitsumori */,
+				4973659B1C19BC6E00837617 /* MitsumoriUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4973659A1C19BC6E00837617 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49FBBF8C1C10C2A200A1A4BB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49F4A5971C583B94007C84A1 /* FrontCardView.xib in Resources */,
+				49FBBF9C1C10C2A200A1A4BB /* LaunchScreen.storyboard in Resources */,
+				49FBBF991C10C2A200A1A4BB /* Assets.xcassets in Resources */,
+				49FBBF971C10C2A200A1A4BB /* Main.storyboard in Resources */,
+				EBFE74F01C4900EB00B7B646 /* BackCardView.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0D338338AD469905FE45C5D7 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		19FA3CFC97A494716FCCD298 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		77A1B287EDAA82F36793B49B /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = ();
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MitsumoriUITests/Pods-MitsumoriUITests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B413487ECFAF19CC720F6703 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		E09A62F1C2781CCB49DC3900 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Mitsumori/Pods-Mitsumori-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		497365981C19BC6E00837617 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49F0E1E11C1B300E0074B5B7 /* SnapshotCapturer.swift in Sources */,
+				4973659F1C19BC6E00837617 /* MitsumoriUITests.swift in Sources */,
+				49F0E1DF1C1B28FF0074B5B7 /* SnapshotHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		49FBBF8A1C10C2A200A1A4BB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				49F4A58D1C583AE3007C84A1 /* CGPoint.swift in Sources */,
+				49FBBFC81C10FB9C00A1A4BB /* UIView.swift in Sources */,
+				49FBBFC41C10EBE600A1A4BB /* CardsViewController.swift in Sources */,
+				49F4A58B1C583AB3007C84A1 /* Transform.swift in Sources */,
+				49F4A5911C583B0C007C84A1 /* Card.swift in Sources */,
+				49F4A58F1C583AF3007C84A1 /* CGSize.swift in Sources */,
+				49F4A5931C583B4C007C84A1 /* Double.swift in Sources */,
+				4959011B1C58F8AB000EE944 /* CustomView.swift in Sources */,
+				490970611C16D9A900200801 /* UIViewTransform.swift in Sources */,
+				EBFE74EE1C4900D000B7B646 /* BackCardView.swift in Sources */,
+				495413B61C1424A20071F4A0 /* CardViewModel.swift in Sources */,
+				49FBBF921C10C2A200A1A4BB /* AppDelegate.swift in Sources */,
+				49F4A5891C583A95007C84A1 /* Animation.swift in Sources */,
+				49C4EEDE1C5E152800B38CD9 /* SelectedCardViewModel.swift in Sources */,
+				49F4A5A11C583DAE007C84A1 /* RotateSelectCardAnimation.swift in Sources */,
+				49FBBFC01C10D05800A1A4BB /* CardCollectionViewCell.swift in Sources */,
+				49F4A5951C583B61007C84A1 /* FrontCardView.swift in Sources */,
+				49F4A59F1C583D88007C84A1 /* RotateRevealSelectedCardAnimation.swift in Sources */,
+				49F4A5A31C583DD8007C84A1 /* SlideToSideRestoreAnimation.swift in Sources */,
+				49F4A5991C583BAF007C84A1 /* Math.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		497365A21C19BC6E00837617 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 49FBBF8D1C10C2A200A1A4BB /* Mitsumori */;
+			targetProxy = 497365A11C19BC6E00837617 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		49FBBF951C10C2A200A1A4BB /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49FBBF961C10C2A200A1A4BB /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		49FBBF9A1C10C2A200A1A4BB /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				49FBBF9B1C10C2A200A1A4BB /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		497365A41C19BC6E00837617 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 274E42B0193BA6FEFA8FD71C /* Pods-MitsumoriUITests.debug.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				INFOPLIST_FILE = MitsumoriUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.MitsumoriUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Mitsumori;
+				USES_XCTRUNNER = YES;
+			};
+			name = Debug;
+		};
+		497365A51C19BC6E00837617 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2757E033CFB59572DA4E60B3 /* Pods-MitsumoriUITests.release.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-iphoneos",
+				);
+				INFOPLIST_FILE = MitsumoriUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.MitsumoriUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = Mitsumori;
+				USES_XCTRUNNER = YES;
+			};
+			name = Release;
+		};
+		49FBBFB41C10C2A200A1A4BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		49FBBFB51C10C2A200A1A4BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Gokarumi S.L. (BD48FG9BMV)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		49FBBFB71C10C2A200A1A4BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F128C4D0067FEE87B2756BC4 /* Pods-Mitsumori.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 10;
+				INFOPLIST_FILE = Mitsumori/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.mitsumori;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		49FBBFB81C10C2A200A1A4BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 83CD4CEBE1B7A02772169FE5 /* Pods-Mitsumori.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 10;
+				INFOPLIST_FILE = Mitsumori/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.karumi.mitsumori;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		497365A31C19BC6E00837617 /* Build configuration list for PBXNativeTarget "MitsumoriUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				497365A41C19BC6E00837617 /* Debug */,
+				497365A51C19BC6E00837617 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		49FBBF891C10C2A200A1A4BB /* Build configuration list for PBXProject "Mitsumori" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				49FBBFB41C10C2A200A1A4BB /* Debug */,
+				49FBBFB51C10C2A200A1A4BB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		49FBBFB61C10C2A200A1A4BB /* Build configuration list for PBXNativeTarget "Mitsumori" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				49FBBFB71C10C2A200A1A4BB /* Debug */,
+				49FBBFB81C10C2A200A1A4BB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 49FBBF861C10C2A200A1A4BB /* Project object */;
+}


### PR DESCRIPTION
The order of rules in ANTLR is quite important, as they take precedence based on when they are defined. Here, I'm putting the ALPHA_NUMERIC and ALPHA_NUMERIC_CAP rules below the QUOTED_STRING and NON_QUOTED_STRING rules so that when we find a single-letter identifier (i.e. a file name) ANTLR detects the *_STRING rules before the ALPHA_NUMERIC_* ones.

This is most likely caused by a badly defined grammar (and probably the lack of proper fragments). However, this is, I think, a good compromise if we don't want to tackle a full rewrite of the grammar.

[tests/ok/011.pbxproj](https://github.com/Serchinastico/Kin/blob/edd19e81896a6b77a82db311ace4d67675b2173d/tests/ok/011.pbxproj) is a copy of 010.pbxproj adding a directory called `C`

**🎟️ Issue**: https://github.com/Serchinastico/Kin/issues/52